### PR TITLE
Fixed error on habit loading that produced the addon to fail when the…

### DIFF
--- a/src/Habit.svelte
+++ b/src/Habit.svelte
@@ -111,9 +111,15 @@
 				return await this.app.vault.read(file).then((result) => {
 					const frontmatter = result.split('---')[1]
 
-					if (!frontmatter) return {}
-
-					return parseYaml(frontmatter)
+					if (!frontmatter){
+						return {"entries": []};
+					}
+					fmParsed = parseYaml(frontmatter)
+					if(fmParsed["entries"] == undefined){
+						fmParsed["entries"] = [];
+					}
+					
+					return fmParsed;
 				})
 			} catch (error) {
 				debugLog(


### PR DESCRIPTION
This small change fixes an issue with the add-on load when a habit file has not the property 'entities' defined causing the habit not able to be clicked (can't mark days as completed).

This is related to the issue #51  and the comment done by @gfkpth 

I did a release to test the fix worked but I did not go through a deep testing.

Please let me know if it helps or if I need to change anything.