### PR TITLE
Replace temporary width sizing hack with an adaptive scaling solution

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,7 @@ div:has(.block-language-habittracker),
 	--habit-cell-width: 25px;
 	--habit-cell-height: 32px;
 	--habit-name-max-width: 173px;
+	--habit-name-min-width: 80px; /* Set an arbitrary minimum limit for name cell width. The value can be changed, but it is necessary*/
 	--habit-name-padding: 8px;
 
 	/* Tick size */
@@ -162,18 +163,43 @@ div:has(.block-language-habittracker),
 	box-sizing: border-box;
 }
 
+
+/* 
+Break the 700px limit on the block language element 
+Applies for the case: 
+"editor/Readable line length" toggled off
+"plugin/Match line length" toggled on
+*/
+body:not(.is-readable-line-width) .block-language-habittracker:has(.habit-tracker--match-line-length) {
+    display: flex !important;
+    width: 100% !important;
+    max-width: 100% !important; /* Main fix 1: scales the whole block accordingly when readable line length is off */ 
+    overflow-x: auto !important; /* Handle scroll correctly if window shrinks */
+}
+
 .habit-tracker {
 	display: grid;
 	grid-template-columns:
-		calc(100% - (var(--date-columns) * var(--habit-cell-width)))
-		repeat(var(--date-columns), var(--habit-cell-width));
+		minmax(var(--habit-name-min-width), calc(100% - (var(--date-columns) * var(--habit-cell-width))))
+        repeat(var(--date-columns), var(--habit-cell-width)) !important;
+		
 	width: 100%;
+	min-width: max-content; /* Main fix 2: Makes habit name cells truly sticky. Now when window is shrinked, the dates do not slide behind the name cells */
 	background-color: var(--habit-bg);
 }
 
 .is-readable-line-width .habit-tracker--match-line-length {
-	min-width: unset;
+	/* 
+	Main fix 3: following 3 lines concerning the display property basically do for the case where both settings RLL and MLL are toggled on, 
+	what Main fix 2 does for the other cases
+	*/
+	display: grid !important;
+    grid-template-columns: 
+        minmax(var(--habit-name-min-width), calc(var(--file-line-width) - (var(--date-columns) * var(--habit-cell-width))))
+        repeat(var(--date-columns), var(--habit-cell-width)) !important;
+
 	width: 100%;
+	min-width: max-content; /* Not sure if necessary. No harm, but potential good */
 	max-width: var(--file-line-width);
 }
 
@@ -200,14 +226,17 @@ div:has(.block-language-habittracker),
 .habit-tracker__row:not(.habit-tracker__header) .habit-tracker__cell {
 	border-top: var(--habit-horizontal-border);
 }
+
 /*
 */
 
 .habit-tracker__cell--name {
 	padding: 0 var(--habit-name-padding);
 	width: 100%;
-	min-width: 40px;
-	max-width: var(--habit-name-max-width);
+	min-width: var(--habit-name-min-width);
+	max-width: auto; /* Main fix 4: This should totally be auto, to prevent the big white blank area between name cells and the tick boxes. It should not be constant */
+
+	box-sizing: border-box;
 	justify-content: start;
 	position: sticky;
 	left: 0;
@@ -225,10 +254,21 @@ div:has(.block-language-habittracker),
 	font-size: var(--habit-name-font-size);
 	text-decoration: none;
 }
-.is-readable-line-width
-	.habit-tracker--match-line-length
+
+.is-readable-line-width 
+	.habit-tracker--match-line-length 
 	.habit-tracker__cell--name {
-	max-width: 100%;
+	padding: 0 var(--habit-name-padding);
+	width: 100%;
+
+	box-sizing: border-box;
+	z-index: 10;
+	justify-content: start;
+	position: sticky;
+	left: 0;
+	background-color: var(--habit-highlight-names);
+
+
 }
 
 .habit-tracker__cell--saturday,

--- a/styles.css
+++ b/styles.css
@@ -156,7 +156,7 @@ div:has(.block-language-habittracker),
 .block-language-habittracker {
 	border: var(--habit-outer-border);
 	border-radius: var(--radius-s);
-	overflow-x: scroll;
+	overflow-x: visible !important; /* Main fix 5: Changed from "scroll" to hand physics over to the grid. The name cells stay fixed (sticky) */
 	width: 100%;
 	max-width: 100%;
 	scrollbar-width: thin;
@@ -184,7 +184,10 @@ body:not(.is-readable-line-width) .block-language-habittracker:has(.habit-tracke
         repeat(var(--date-columns), var(--habit-cell-width)) !important;
 		
 	width: 100%;
-	min-width: max-content; /* Main fix 2: Makes habit name cells truly sticky. Now when window is shrinked, the dates do not slide behind the name cells */
+	/* Main fix 6.1: we make the habits grid scrollable when shrinked when RLL off MLL off */
+	min-width: 0 !important; 		/* changed from max-content to unlock layout shrinking */
+	max-width: 100% !important;     /* Force containment within view boundaries */
+	overflow-x: auto !important;    /* Make the grid own the scrollbar context */
 	background-color: var(--habit-bg);
 }
 
@@ -199,7 +202,10 @@ body:not(.is-readable-line-width) .block-language-habittracker:has(.habit-tracke
         repeat(var(--date-columns), var(--habit-cell-width)) !important;
 
 	width: 100%;
-	min-width: max-content; /* Not sure if necessary. No harm, but potential good */
+	/* Main fix 6.2: we make the habits grid scrollable when shrinked when RLL on MLL on */
+	min-width: 0 !important; 		/* changed from max-content to unlock layout shrinking */
+	max-width: 100% !important;     /* Force containment within view boundaries */
+	overflow-x: auto !important;    /* Make the grid own the scrollbar context */
 	max-width: var(--file-line-width);
 }
 
@@ -425,3 +431,26 @@ body:not(.is-readable-line-width) .block-language-habittracker:has(.habit-tracke
 .habit-tracker__header .habit-tracker__cell--today {
 	color: var(--habit-name-text-color);
 }
+
+/* FIX: Handle nested overflow when both Readable Line Length (RLL) 
+   and Match Line Length (MLL) are toggled on.
+*/
+
+/* 1. Turn off outer scroll behaviors on the markdown wrapper */
+.cm-preview-code-block.markdown-rendered:has(.block-language-habittracker) {
+    overflow-x: visible !important;
+}
+
+.block-language-habittracker {
+    overflow-x: visible !important; /* Prevent the outer container from moving */
+}
+
+/* 2. Force the grid itself to contain the horizontal scrollbar context */
+.habit-tracker,
+.is-readable-line-width .habit-tracker--match-line-length {
+    min-width: 0 !important;         /* Breaks the rigid brick behavior */
+    max-width: 100% !important;      /* Forces the grid to stick to the visible layout width */
+    overflow-x: auto !important;     /* Empowers the grid to own the scrolling physics internally */
+    scrollbar-width: thin;
+}
+

--- a/styles.css
+++ b/styles.css
@@ -156,25 +156,25 @@ div:has(.block-language-habittracker),
 	border: var(--habit-outer-border);
 	border-radius: var(--radius-s);
 	overflow-x: scroll;
-	width: fit-content;
+	width: 100%;
 	max-width: 100%;
 	scrollbar-width: thin;
+	box-sizing: border-box;
 }
 
 .habit-tracker {
 	display: grid;
-	grid-template-columns: 1fr repeat(
-			var(--date-columns),
-			var(--habit-cell-width)
-		);
-	width: fit-content;
+	grid-template-columns:
+		calc(100% - (var(--date-columns) * var(--habit-cell-width)))
+		repeat(var(--date-columns), var(--habit-cell-width));
+	width: 100%;
 	background-color: var(--habit-bg);
 }
 
 .is-readable-line-width .habit-tracker--match-line-length {
-	min-width: calc(
-		var(--file-line-width) - 2px
-	); /* TODO: this is a hack since I know the widht of the border. but it won't scale. figure out a way to fix this that hopefully doesn't break overrides people added in place */
+	min-width: unset;
+	width: 100%;
+	max-width: var(--file-line-width);
 }
 
 .habit-tracker__row {
@@ -206,6 +206,7 @@ div:has(.block-language-habittracker),
 .habit-tracker__cell--name {
 	padding: 0 var(--habit-name-padding);
 	width: 100%;
+	min-width: 40px;
 	max-width: var(--habit-name-max-width);
 	justify-content: start;
 	position: sticky;


### PR DESCRIPTION
Replace hardcoded temporary width sizing hack that uses constant values, with an adaptive scaling solution.

The comments following the line 175 in the original file styles.css mentioned this issue is already planned to be handled later, indicated by TODO flag.

The solution relies on 2 primary changes:

	1. We set the box-sizing property of the ".block-language-habittracker" class to be border-box.

   	THis is very important, as it changes widthcalculation completely.

   	content-box (default): Total Rendered Width = Width (provided value) + Padding + Border
  	border-box (solution): Width = Content Width + Padding + Border

   	in content-box, when we give line length as input, it adds padding and margin on top of it to render. But in border-box, the total rendered width becomes the line length.

	2. We fix the original part that is intended to be handled later (TODO) that calculates grid-template-column sizes in the class ".habit-tracker". Now, the calculation is based on the relative width (100%).