### PR TITLE
fix: respect showStreaks=false for streak count display

### DIFF
--- a/src/Habit.svelte
+++ b/src/Habit.svelte
@@ -31,13 +31,14 @@
 			customStyles = ''
 		}
 	}
+	$: showStreaks =
+		userSettings.showStreaks !== undefined
+			? userSettings.showStreaks
+			: globalSettings.showStreaks
+
 	$: renderedDates = (() => {
 		const maxGap = Number(frontmatter.maxGap) || 0
 		const entrySet = new Set(entries)
-		const showStreaks =
-			userSettings.showStreaks !== undefined
-				? userSettings.showStreaks
-				: globalSettings.showStreaks
 		const gapStyle =
 			userSettings.gapStyle !== undefined
 				? userSettings.gapStyle
@@ -343,7 +344,7 @@
 			>
 				<span
 					class="habit-tick__inner"
-				>{#if day.streakEnd && day.streakCount > 1}{day.streakCount}{/if}</span>
+				>{#if showStreaks && day.streakEnd && day.streakCount > 1}{day.streakCount}{/if}</span>
 			</div>
 		{/each}
 	{/if}


### PR DESCRIPTION
Setting `showStreaks` to `false` didn't disable showing counts because the streak count was rendered in the template without checking the `showStreaks` setting.

This fix extracts `showStreaks` as a top-level reactive variable in `Habit.svelte` so it's accessible in the template, then gates the count rendering on it.

Fixes #89

Generated with [Claude Code](https://claude.ai/code)